### PR TITLE
Add seed for random in test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+import random
+
+@pytest.fixture(scope="session", autouse=True)
+def set_random_seed():
+    """Set a fixed seed for random number generation to ensure reproducibility."""
+    random.seed(42)
+    yield


### PR DESCRIPTION
Hello, in this PR I add a fixed `random.seed(42)` in the conftest.py to ensure deterministic behavior for tests that utilize Python's random module.

The change addresses variability in several tests, which rely on random operations. Without a fixed seed, these tests could produce inconsistent results across runs, complicating debugging and issue reproduction. By setting the seed at the start of the test session, this modification enhances test consistency and reliability, ensuring reproducible outcomes.